### PR TITLE
Change to compileOnly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,5 +6,5 @@ group 'flavor.pie'
 version '1.1.1'
 
 dependencies {
-    compile 'org.spongepowered:spongeapi:4.1.0'
+    compileOnly 'org.spongepowered:spongeapi:4.1.0'
 }


### PR DESCRIPTION
[Not too long ago](https://blog.gradle.org/introducing-compile-only-dependencies) compileOnly dependencies were introduced. 

This allows us to easily specify what to include and exclude with shadowJar :man_dancing: 

Currently if we use shadowJar it will _also_ shadow in all of Sponge as well, but if we change **compile** to **compileOnly** we can safely use it. 